### PR TITLE
Handle missing player images

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ pygbag --build mario_game.py
 3. 跳躍圖片 (`mario_jump.png`)
 
 若沒有提供跑步或跳躍圖片，遊戲仍可執行，但角色將顯示為空白。
+
+圖片載入採用 `pygame.image.load`，若檔案不存在或發生 `pygame.error`，程式會以
+`pygame.Surface` 產生空白圖像取代，確保遊戲可繼續運作。

--- a/mario_game.py
+++ b/mario_game.py
@@ -8,16 +8,27 @@ GRAVITY = 0.5
 class Player(pygame.sprite.Sprite):
     def __init__(self, x, y):
         super().__init__()
-        # 載入靜止、跑步與跳躍圖片
-        self.image_idle = pygame.image.load(
-            os.path.join("images", "mario.png")
-        ).convert_alpha()
-        self.image_run = pygame.image.load(
-            os.path.join("images", "mario_run.png")
-        ).convert_alpha()
-        self.image_jump = pygame.image.load(
-            os.path.join("images", "mario_jump.png")
-        ).convert_alpha()
+        # 載入靜止、跑步與跳躍圖片，若檔案不存在則以空白圖像取代
+        try:
+            self.image_idle = pygame.image.load(
+                os.path.join("images", "mario.png")
+            ).convert_alpha()
+        except (pygame.error, FileNotFoundError):
+            self.image_idle = pygame.Surface((40, 40), pygame.SRCALPHA)
+
+        try:
+            self.image_run = pygame.image.load(
+                os.path.join("images", "mario_run.png")
+            ).convert_alpha()
+        except (pygame.error, FileNotFoundError):
+            self.image_run = pygame.Surface(self.image_idle.get_size(), pygame.SRCALPHA)
+
+        try:
+            self.image_jump = pygame.image.load(
+                os.path.join("images", "mario_jump.png")
+            ).convert_alpha()
+        except (pygame.error, FileNotFoundError):
+            self.image_jump = pygame.Surface(self.image_idle.get_size(), pygame.SRCALPHA)
 
         self.image = self.image_idle
         self.rect = self.image.get_rect(topleft=(x, y))


### PR DESCRIPTION
## Summary
- create fallback surfaces when loading player images
- explain error handling in README

## Testing
- `python -m py_compile mario_game.py`

------
https://chatgpt.com/codex/tasks/task_e_68427bc9eab08332af2b9ae373d36fde