### PR TITLE
調整轉盤動畫與顯示時機

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -20,11 +20,17 @@ function drawWheel(prizes) {
     }
 }
 
-function spinWheel(index) {
+function spinWheel(index, prize) {
     const wheel = document.getElementById('wheel');
     const degPerPrize = 360 / prizes.length;
     const rotation = 360 * 3 + (index * degPerPrize) + degPerPrize / 2;
-    wheel.style.transform = `rotate(-${rotation}deg)`;
+    wheel.style.transform = `rotate(${rotation}deg)`;
+    const result = document.getElementById('result');
+    const handler = () => {
+        result.innerText = `恭喜獲得 ${prize} 元！`;
+        wheel.removeEventListener('transitionend', handler);
+    };
+    wheel.addEventListener('transitionend', handler);
 }
 
 window.onload = function() {
@@ -32,7 +38,6 @@ window.onload = function() {
     document.getElementById('spin').onclick = async function() {
         const res = await fetch('/spin');
         const data = await res.json();
-        spinWheel(data.index);
-        document.getElementById('result').innerText = `恭喜獲得 ${data.prize} 元！`;
+        spinWheel(data.index, data.prize);
     };
 };

--- a/static/style.css
+++ b/static/style.css
@@ -11,7 +11,7 @@ body {
 }
 
 #wheel {
-    transition: transform 4s ease-out;
+    transition: transform 3s ease-in-out;
 }
 
 #pointer {


### PR DESCRIPTION
## 變更內容
- 將轉盤動畫調整為 3 秒 `ease-in-out`，方向改為順時針旋轉
- 抽獎結果待動畫結束後再顯示

## 測試結果
- `python -m unittest discover tests` **失敗**：缺少 `flask` 套件
  - `ModuleNotFoundError: No module named 'flask'`


------
https://chatgpt.com/codex/tasks/task_e_6842824411748332861d7eebfc4ceac4