### PR TITLE
修正箭頭方向與轉盤停點

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -23,7 +23,7 @@ function drawWheel(prizes) {
 function spinWheel(index, prize) {
     const wheel = document.getElementById('wheel');
     const degPerPrize = 360 / prizes.length;
-    const rotation = 360 * 3 + (index * degPerPrize) + degPerPrize / 2;
+    const rotation = 360 * 3 + 270 - index * degPerPrize - degPerPrize / 2;
     wheel.style.transform = `rotate(${rotation}deg)`;
     const result = document.getElementById('result');
     const handler = () => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
     <h1>轉盤抽獎機</h1>
     <div id="wheel-container">
         <canvas id="wheel" width="500" height="500"></canvas>
-        <div id="pointer">▲</div>
+        <div id="pointer">▼</div>
     </div>
     <button id="spin">開始抽獎</button>
     <p id="result"></p>


### PR DESCRIPTION
## 摘要
- 轉盤指示箭頭改成倒三角形
- 調整旋轉公式，讓中獎項目停在箭頭下方

## 測試
- `python -m unittest discover tests` *(失敗：找不到 flask 套件)*

------
https://chatgpt.com/codex/tasks/task_e_68428379d6b48332af7ea020fde10fbf